### PR TITLE
fix: WebSocket conversation start in editor playground

### DIFF
--- a/editor/src/hooks/usePlaygroundChat.ts
+++ b/editor/src/hooks/usePlaygroundChat.ts
@@ -150,8 +150,8 @@ export function usePlaygroundChat() {
     ws.current.send(JSON.stringify(msg));
     setMessages([]);
     setThinking(null);
-    // Reset conversation started flag to allow re-starting
-    setConversationStarted(false);
+    // Set conversation started optimistically - server will confirm
+    setConversationStarted(true);
   }, []);
   
   const sendMessage = useCallback((text: string) => {


### PR DESCRIPTION
## Summary

Fixes the 'No active session' error when sending messages in merchant-initiated workflows (like ad hoc).

## Problem

When using merchant-initiated workflows in the editor playground, sending a message would fail with:
```
No active session. Please start a conversation first using 'start_conversation' message type.
```

## Root Cause

The `startConversation` function was incorrectly setting `conversationStarted` to `false` instead of `true`. This caused the MerchantInitiatedView to think the conversation hadn't started, even after calling `startConversation()`.

## Fix

Changed the flag to be set optimistically to `true` when starting a conversation. The server will confirm with a `conversation_started` message.

## Test Plan

1. Open the editor playground
2. Select an ad hoc workflow (or any merchant-initiated workflow)
3. Type a message and send it
4. Verify the conversation starts properly and the message is sent without errors

🤖 Generated with [Claude Code](https://claude.ai/code)